### PR TITLE
feat: add ARM Linux (aarch64) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,11 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - name: Build Linux AppImage
         run: nix build .#linux-appimage
+
+  build-linux-arm:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - name: Build Linux ARM AppImage
+        run: nix build .#linux-appimage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,17 +99,37 @@ jobs:
 
       - name: Package Linux AppImage
         run: |
-          cp -L result "Appreciate-Linux-${{ inputs.version }}.AppImage"
-          chmod +x "Appreciate-Linux-${{ inputs.version }}.AppImage"
+          cp -L result "Appreciate-Linux-x86_64-${{ inputs.version }}.AppImage"
+          chmod +x "Appreciate-Linux-x86_64-${{ inputs.version }}.AppImage"
 
       - name: Upload Linux AppImage
         uses: actions/upload-artifact@v4
         with:
           name: linux-appimage
-          path: "Appreciate-Linux-*.AppImage"
+          path: "Appreciate-Linux-x86_64-*.AppImage"
+
+  build-linux-arm:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build Linux ARM AppImage
+        run: nix build .#linux-appimage
+
+      - name: Package Linux ARM AppImage
+        run: |
+          cp -L result "Appreciate-Linux-ARM-${{ inputs.version }}.AppImage"
+          chmod +x "Appreciate-Linux-ARM-${{ inputs.version }}.AppImage"
+
+      - name: Upload Linux ARM AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-arm-appimage
+          path: "Appreciate-Linux-ARM-*.AppImage"
 
   release:
-    needs: [build-macos, build-android, build-windows, build-linux]
+    needs: [build-macos, build-android, build-windows, build-linux, build-linux-arm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -163,4 +183,5 @@ jobs:
             macos-dmg/Appreciate-macOS-*.dmg
             android-apk/Appreciate-Android-*.apk
             windows-exe/Appreciate-Windows-*.exe
-            linux-appimage/Appreciate-Linux-*.AppImage
+            linux-appimage/Appreciate-Linux-x86_64-*.AppImage
+            linux-arm-appimage/Appreciate-Linux-ARM-*.AppImage

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ nix run github:srid/Appreciate
 
 ### Install from AppImage
 
-1. Download the latest `.AppImage` from [Releases](../../releases)
+AppImages are available for both **x86_64** and **ARM (aarch64)**.
+
+1. Download the latest `.AppImage` for your architecture from [Releases](../../releases)
 2. Make executable and run:
    ```bash
    chmod +x Appreciate-Linux-*.AppImage
@@ -143,7 +145,7 @@ nix run github:srid/Appreciate
 1. Go to [Actions → Release](../../actions/workflows/release.yml)
 2. Click **Run workflow**
 3. Enter a version tag (e.g. `v1.1.0`)
-4. The workflow builds macOS DMG, Android APK, Windows EXE, and Linux AppImage, and attaches all to the Release
+4. The workflow builds macOS DMG, Android APK, Windows EXE, and Linux AppImages (x86_64 + ARM), and attaches all to the Release
 
 ## License
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,7 +123,8 @@
             <div class="platform-icon">🐧</div>
             <h3>Linux <span class="badge badge-beta">beta</span></h3>
             <p>Python + GTK4. Install via Nix or download the AppImage — runs on any Linux distro.</p>
-            <a href="https://github.com/srid/Appreciate/releases" class="btn btn-small" data-platform="Linux" data-ext=".AppImage">Download AppImage</a>
+            <a href="https://github.com/srid/Appreciate/releases" class="btn btn-small" data-platform="Linux-x86_64" data-ext=".AppImage">Download x86_64</a>
+            <a href="https://github.com/srid/Appreciate/releases" class="btn btn-small" data-platform="Linux-ARM" data-ext=".AppImage" style="margin-top:8px">Download ARM</a>
             <div style="margin-top:12px"><code style="color:#8a8a9a;font-size:0.85rem;">nix run github:srid/Appreciate</code></div>
         </div>
     </div>


### PR DESCRIPTION
Adds native ARM Linux (aarch64) AppImage builds to CI and releases.

## Changes
- **CI**: New `build-linux-arm` job using `ubuntu-24.04-arm` native runner
- **Release**: ARM AppImage (`Appreciate-Linux-ARM-*.AppImage`) attached alongside x86_64
- **Website**: Separate download buttons for x86_64 and ARM AppImages
- **README**: Documents ARM AppImage availability

> **Note**: The x86_64 AppImage is renamed from `Appreciate-Linux-*.AppImage` to `Appreciate-Linux-x86_64-*.AppImage` to disambiguate architectures.