### PR TITLE
Add release and releases targets to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,3 +30,12 @@ build-windows:
 # Build Linux AppImage
 build-linux:
     nix build .#linux-appimage
+
+# List recent GitHub releases
+releases:
+    gh release list --limit 5
+
+# Create a new GitHub release (triggers CI build for all platforms)
+release version:
+    gh workflow run release.yml -f version={{version}}
+    @echo "🚀 Release {{version}} triggered. Watch: gh run list --workflow=release.yml"


### PR DESCRIPTION
## Summary
- Add `just releases` to list the 5 most recent GitHub releases
- Add `just release <version>` to trigger the release CI workflow (`release.yml`)

## Test plan
- [ ] `just releases` lists recent releases
- [ ] `just release v1.5.1` triggers the workflow